### PR TITLE
Make site mobile-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <meta name="theme-color" content="#ffffff">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Chrisbump">
   <title>Chrisbump</title>
+  <link rel="manifest" href="./manifest.json">
+  <link rel="apple-touch-icon" href="./icon.svg">
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
   <link rel="stylesheet" href="./dist/flash.css">
 </head>
@@ -11,9 +17,9 @@
 <div class="fistbump-div">
   <button
     id="fistbump-btn"
-    data-message="You fistbumped a Chris! Life is good."
     data-type="success"
     data-timeout="4000"
+    aria-label="Fist bump a random Chris"
     >🤜🤛</button>
 </div>
   <script src="./dist/flash.min.js"></script>

--- a/dist/app.js
+++ b/dist/app.js
@@ -1,31 +1,40 @@
-(function (window, document, $, undefined) {
+(function (window, document, undefined) {
 
   'use strict';
 
+  const names = [
+    "Chris Steinmeyer",
+    "Chris Frost",
+    "Chris Prewitt"
+  ];
+
   function randomChris() {
-    const array = ["Chris Steinmeyer",
-		   "Chris Frost",
-		   "Chris Prewitt"];
-
-    const randomIndex = Math.floor(Math.random() * array.length);
-    const randomElement = array[randomIndex];
-
-    console.log(randomElement);
-    return randomElement;
+    return names[Math.floor(Math.random() * names.length)];
   }
-  document.addEventListener('DOMContentLoaded', function () {
-    //remove first h1 on the page
-    document.getElementById('fistbump-btn').addEventListener('click', function () {
-    new window.FlashMessage(
-        `You fistbumped  ${randomChris()}! Life is good!`,
-	this.dataset.type,
-        {
-          timeout: this.dataset.timeout,
-          progress: true
-        });
 
+  function fistBump(btn) {
+    if ('vibrate' in navigator) {
+      navigator.vibrate(50);
+    }
+    new window.FlashMessage(
+      `You fistbumped ${randomChris()}! Life is good!`,
+      btn.dataset.type,
+      { timeout: btn.dataset.timeout, progress: true }
+    );
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const btn = document.getElementById('fistbump-btn');
+
+    // touchend fires immediately without 300ms delay; preventDefault blocks the ghost click
+    btn.addEventListener('touchend', function (e) {
+      e.preventDefault();
+      fistBump(this);
     });
 
+    btn.addEventListener('click', function () {
+      fistBump(this);
+    });
   }, false);
 
-})(window, document)
+})(window, document);

--- a/dist/flash.css
+++ b/dist/flash.css
@@ -1,9 +1,21 @@
 /* FLASHJS - DEFAULT THEME */
 /* FLASH JS THEME VARIABLES */
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
 #fistbump-btn {
-  width: 50%;
-  height: 50%;
-  font-size: 350px;
+  background: none;
+  border: none;
+  padding: 1rem;
+  cursor: pointer;
+  font-size: clamp(80px, 40vmin, 350px);
+  line-height: 1;
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
 }
 .fistbump-div {
   display: flex;

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="80" fill="#ffffff"/>
+  <text x="256" y="370" font-size="300" text-anchor="middle">🤜🤛</text>
+</svg>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "Chrisbump",
+  "short_name": "Chrisbump",
+  "description": "Give a random Chris a fist bump",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "./icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Responsive button sizing with `clamp(80px, 40vmin, 350px)` — scales from mobile to desktop without overflowing
- `touch-action: manipulation` + `touchend`/`preventDefault` eliminates the 300ms tap delay and ghost click
- `navigator.vibrate(50)` haptic feedback on fist bump
- Strip default browser button chrome; add `-webkit-tap-highlight-color: transparent` and `user-select: none`
- Web app manifest (`manifest.json`) + SVG icon (`icon.svg`) for Add to Home Screen on Android/Chrome
- Apple mobile web app meta tags for iOS home screen support
- Also fixes the double-space bug in the flash message and adds `aria-label` to the button

## Test plan

- [ ] Open on a real iOS or Android device and verify the button scales correctly
- [ ] Tap the button and confirm the flash toast appears without noticeable delay
- [ ] Verify haptic feedback fires on a device that supports `navigator.vibrate`
- [ ] On Android Chrome, confirm "Add to Home Screen" prompt appears (or use the browser menu)
- [ ] On iOS Safari, use Share → Add to Home Screen and verify the icon and app title appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)