### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,5 @@
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <meta name="theme-color" content="#ffffff">
-  <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta name="apple-mobile-web-app-status-bar-style" content="default">
-  <meta name="apple-mobile-web-app-title" content="Chrisbump">
-  <title>Chrisbump</title>
-  <link rel="manifest" href="./manifest.json">
-  <link rel="apple-touch-icon" href="./icon.svg">
-  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-  <link rel="stylesheet" href="./dist/flash.css">
-</head>
-<body>
-<div class="fistbump-div">
-  <button
-    id="fistbump-btn"
-    data-type="success"
-    data-timeout="4000"
-    aria-label="Fist bump a random Chris"
-    >🤜🤛</button>
-</div>
-  <script src="./dist/flash.min.js"></script>
-  <script src="./dist/app.js"></script>
-</body>
-</html>
+# Chrisbump
+
+Give a random Chris a fist bump. 🤜🤛
+
+Live at [chrisbump.com](http://chrisbump.com).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <meta name="theme-color" content="#ffffff">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="apple-mobile-web-app-title" content="Chrisbump">
+  <title>Chrisbump</title>
+  <link rel="manifest" href="./manifest.json">
+  <link rel="apple-touch-icon" href="./icon.svg">
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <link rel="stylesheet" href="./dist/flash.css">
+</head>
+<body>
+<div class="fistbump-div">
+  <button
+    id="fistbump-btn"
+    data-type="success"
+    data-timeout="4000"
+    aria-label="Fist bump a random Chris"
+    >🤜🤛</button>
+</div>
+  <script src="./dist/flash.min.js"></script>
+  <script src="./dist/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Moves the site HTML from `README.md` to `index.html` (GitHub Pages serves this automatically)
- Replaces `README.md` with a simple markdown description so the repo page looks sensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)