### PR TITLE
Keep fists knuckle-to-knuckle on narrow viewports

### DIFF
--- a/dist/flash.css
+++ b/dist/flash.css
@@ -12,6 +12,7 @@ html, body {
   cursor: pointer;
   font-size: clamp(80px, 40vmin, 350px);
   line-height: 1;
+  white-space: nowrap;
   -webkit-tap-highlight-color: transparent;
   touch-action: manipulation;
   user-select: none;


### PR DESCRIPTION
## Summary

Adds `white-space: nowrap` to the button so the two fist emojis can never wrap to separate lines. The existing `clamp(80px, 40vmin, 350px)` sizing already scales them down to fit the viewport — this just prevents the line break from happening in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)