### PR TITLE
Add fist bump animation

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -13,14 +13,23 @@
   }
 
   function fistBump(btn) {
-    if ('vibrate' in navigator) {
-      navigator.vibrate(50);
-    }
-    new window.FlashMessage(
-      `You fistbumped ${randomChris()}! Life is good!`,
-      btn.dataset.type,
-      { timeout: btn.dataset.timeout, progress: true }
-    );
+    if (btn.classList.contains('bumping')) return;
+
+    btn.classList.add('bumping');
+
+    // Haptic fires at the moment of impact (70% through the 600ms animation)
+    setTimeout(function () {
+      if ('vibrate' in navigator) navigator.vibrate(50);
+    }, 420);
+
+    setTimeout(function () {
+      btn.classList.remove('bumping');
+      new window.FlashMessage(
+        `You fistbumped ${randomChris()}! Life is good!`,
+        btn.dataset.type,
+        { timeout: btn.dataset.timeout, progress: true }
+      );
+    }, 650);
   }
 
   document.addEventListener('DOMContentLoaded', function () {

--- a/dist/flash.css
+++ b/dist/flash.css
@@ -5,6 +5,27 @@ html, body {
   padding: 0;
   height: 100%;
 }
+.fist {
+  display: inline-block;
+}
+
+@keyframes fist-left-bump {
+  0%   { transform: translateX(0);       animation-timing-function: ease-out; }
+  30%  { transform: translateX(-0.25em); animation-timing-function: ease-in;  }
+  70%  { transform: translateX(0.03em);  animation-timing-function: ease-out; }
+  100% { transform: translateX(0); }
+}
+
+@keyframes fist-right-bump {
+  0%   { transform: translateX(0);       animation-timing-function: ease-out; }
+  30%  { transform: translateX(0.25em);  animation-timing-function: ease-in;  }
+  70%  { transform: translateX(-0.03em); animation-timing-function: ease-out; }
+  100% { transform: translateX(0); }
+}
+
+#fistbump-btn.bumping .fist-left  { animation: fist-left-bump  0.6s forwards; }
+#fistbump-btn.bumping .fist-right { animation: fist-right-bump 0.6s forwards; }
+
 #fistbump-btn {
   background: none;
   border: none;

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     data-type="success"
     data-timeout="4000"
     aria-label="Fist bump a random Chris"
-    >🤜🤛</button>
+    ><span class="fist fist-left">🤜</span><span class="fist fist-right">🤛</span></button>
 </div>
   <script src="./dist/flash.min.js"></script>
   <script src="./dist/app.js"></script>


### PR DESCRIPTION
## Summary

- Splits the two emoji into separate `<span>` elements so they can be animated independently
- CSS keyframes pull the fists apart, then slam them back together with a slight overshoot for feel
- Haptic (`navigator.vibrate(50)`) fires at 420ms — the moment of impact — rather than on tap
- Flash message appears 650ms in, after the animation settles
- Double-tapping during the animation is ignored

## Test plan

- [ ] Click/tap the button and confirm the pull-apart → slam-together animation plays
- [ ] Confirm the flash message appears after the animation, not immediately on tap
- [ ] On a real device, confirm haptic fires at the moment the fists connect, not on tap
- [ ] Confirm rapid tapping doesn't stack animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)