### PR TITLE
Close knuckle gap at rest and at impact

### DIFF
--- a/dist/flash.css
+++ b/dist/flash.css
@@ -9,17 +9,20 @@ html, body {
   display: inline-block;
 }
 
+/* Pull the two emoji together so knuckles touch at rest */
+.fist-left { margin-right: -0.08em; }
+
 @keyframes fist-left-bump {
   0%   { transform: translateX(0);       animation-timing-function: ease-out; }
   30%  { transform: translateX(-0.25em); animation-timing-function: ease-in;  }
-  70%  { transform: translateX(0.03em);  animation-timing-function: ease-out; }
+  70%  { transform: translateX(0.12em);  animation-timing-function: ease-out; }
   100% { transform: translateX(0); }
 }
 
 @keyframes fist-right-bump {
   0%   { transform: translateX(0);       animation-timing-function: ease-out; }
   30%  { transform: translateX(0.25em);  animation-timing-function: ease-in;  }
-  70%  { transform: translateX(-0.03em); animation-timing-function: ease-out; }
+  70%  { transform: translateX(-0.12em); animation-timing-function: ease-out; }
   100% { transform: translateX(0); }
 }
 


### PR DESCRIPTION
## Summary

- Adds `margin-right: -0.08em` to the left fist so knuckles touch in the resting state (closes the natural character spacing gap between emoji)
- Increases the impact overshoot from `0.03em` to `0.12em` so the fists visibly press into each other at the moment of the bump

## Test plan

- [ ] Verify knuckles are touching at rest (no gap between the two fists)
- [ ] Tap and confirm the fists visibly press together at impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)