### PR TITLE
Fix fist overlap on desktop

### DIFF
--- a/dist/flash.css
+++ b/dist/flash.css
@@ -9,8 +9,10 @@ html, body {
   display: inline-block;
 }
 
-/* Pull the two emoji together so knuckles touch at rest */
-.fist-left { margin-right: -0.08em; }
+/* Pull the two emoji together on touch devices where emoji have more internal padding */
+@media (hover: none) {
+  .fist-left { margin-right: -0.08em; }
+}
 
 @keyframes fist-left-bump {
   0%   { transform: translateX(0);       animation-timing-function: ease-out; }


### PR DESCRIPTION
## Summary

Wraps the `margin-right: -0.08em` in `@media (hover: none)` so it only applies on touch devices. Desktop emoji fonts have less internal padding than mobile emoji fonts, causing the negative margin to produce overlap on desktop while being necessary on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)