### PR TITLE
Add 💥 boom emoji at moment of impact

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -17,11 +17,13 @@
 
     btn.classList.add('bumping');
 
-    // Haptic fires at the moment of impact (70% through the 600ms animation)
+    // Impact moment: haptic + boom emoji
     setTimeout(function () {
       if ('vibrate' in navigator) navigator.vibrate(50);
+      btn.classList.add('booming');
     }, 420);
 
+    // Fist animation done: remove bumping, show flash message
     setTimeout(function () {
       btn.classList.remove('bumping');
       new window.FlashMessage(
@@ -30,6 +32,11 @@
         { timeout: btn.dataset.timeout, progress: true }
       );
     }, 650);
+
+    // Boom animation done: remove booming
+    setTimeout(function () {
+      btn.classList.remove('booming');
+    }, 900);
   }
 
   document.addEventListener('DOMContentLoaded', function () {

--- a/dist/flash.css
+++ b/dist/flash.css
@@ -31,7 +31,27 @@ html, body {
 #fistbump-btn.bumping .fist-left  { animation: fist-left-bump  0.6s forwards; }
 #fistbump-btn.bumping .fist-right { animation: fist-right-bump 0.6s forwards; }
 
+.boom {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
+  pointer-events: none;
+  line-height: 1;
+}
+
+@keyframes boom-appear {
+  0%   { transform: translate(-50%, -50%) scale(0);   opacity: 0; }
+  15%  { transform: translate(-50%, -50%) scale(1.4); opacity: 1; }
+  50%  { transform: translate(-50%, -50%) scale(1.1); opacity: 1; }
+  100% { transform: translate(-50%, -50%) scale(0.8); opacity: 0; }
+}
+
+#fistbump-btn.booming .boom { animation: boom-appear 0.45s ease-out forwards; }
+
 #fistbump-btn {
+  position: relative;
   background: none;
   border: none;
   padding: 1rem;

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     data-type="success"
     data-timeout="4000"
     aria-label="Fist bump a random Chris"
-    ><span class="fist fist-left">🤜</span><span class="fist fist-right">🤛</span></button>
+    ><span class="fist fist-left">🤜</span><span class="boom">💥</span><span class="fist fist-right">🤛</span></button>
 </div>
   <script src="./dist/flash.min.js"></script>
   <script src="./dist/app.js"></script>


### PR DESCRIPTION
## Summary

- Adds a `💥` span between the fist spans, hidden by default
- At the 420ms impact moment, a `booming` class triggers a scale-up animation (0 → 1.4x → fade out over 450ms)
- Positioned absolutely so it overlaps both fists rather than pushing them apart
- Haptic, boom, and flash message all fire in sequence from the same impact timeout

## Test plan

- [ ] Click/tap and confirm 💥 appears at the moment the fists meet
- [ ] Confirm it overlaps the fists and fades before the flash message appears
- [ ] Confirm resting state shows no boom emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)