### PR TITLE
Fix boom emoji rendering beneath right fist

### DIFF
--- a/dist/flash.css
+++ b/dist/flash.css
@@ -7,6 +7,8 @@ html, body {
 }
 .fist {
   display: inline-block;
+  position: relative;
+  z-index: 0;
 }
 
 /* Pull the two emoji together on touch devices where emoji have more internal padding */
@@ -39,6 +41,7 @@ html, body {
   opacity: 0;
   pointer-events: none;
   line-height: 1;
+  z-index: 1;
 }
 
 @keyframes boom-appear {


### PR DESCRIPTION
## Summary

The 💥 was appearing on top of the left fist but beneath the right fist because DOM order determines paint order for non-positioned elements. Fix: add `position: relative; z-index: 0` to `.fist` and `z-index: 1` to `.boom` to establish an explicit stacking order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)